### PR TITLE
Fixed: preen would fail silently because the error in callback was ne…

### DIFF
--- a/tasks/preen.js
+++ b/tasks/preen.js
@@ -31,7 +31,13 @@ module.exports = function(grunt) {
       //options.debug = true;
 
     var done = this.async();
-    preen.preen(options, function(){
+    preen.preen(options, function(err, res){
+      
+      // stop if preen encounters an error
+      if(err) {
+        grunt.fail.fatal(err);
+      }
+      
       grunt.log.writeln('Preen Complete.');
       done();
     });


### PR DESCRIPTION
…ver checked

If preen fails because the preen configuration in bower.json has an invalid path, it would fail; however the grunt-preen task report as completed successfully without mentioning any error.
